### PR TITLE
contract-call bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "blockstack-core"
 version = "0.0.1"
-source = "git+https://github.com/blockstack/stacks-blockchain?branch=exp/clarity-bench-no-op#e672a37e5ac19a4a3a895cbc6009f0117e39a12b"
+source = "git+https://github.com/blockstack/stacks-blockchain?branch=dev/clarity-benchmarking#d219261ba07f5a96e91cae29a96aa0203279f283"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 criterion = "0.3.4"
 
 [dependencies]
-blockstack-core = { git = "https://github.com/blockstack/stacks-blockchain", branch = "exp/clarity-bench-no-op" }
+blockstack-core = { git = "https://github.com/blockstack/stacks-blockchain", branch = "dev/clarity-benchmarking" }
+# blockstack-core = { path = "../stacks-blockchain" }
 rand = "0.8.3"
 lazy_static = "1.4.0"
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -587,7 +587,7 @@ fn helper_deepen_typing_context(
         let mut cost_tracker = LimitedCostTracker::new_free();
         let headers_db = SimHeadersDB::new();
         let mut marf = setup_chain_state(MARF_SCALE, &headers_db);
-        let mut marf_store = marf.begin(&StacksBlockId(as_hash(0)), &StacksBlockId(as_hash(1)));
+        let mut marf_store = marf.begin(&StacksBlockId(as_hash(60)), &StacksBlockId(as_hash(61)));
         let mut analysis_db = marf_store.as_analysis_db();
         let mut type_checker = TypeChecker::new(&mut analysis_db, cost_tracker.clone());
 
@@ -710,7 +710,7 @@ fn bench_contract_storage(c: &mut Criterion) {
         let headers_db = SimHeadersDB::new();
 
         let mut marf = setup_chain_state(MARF_SCALE, &headers_db);
-        let mut marf_store = marf.begin(&StacksBlockId(as_hash(0)), &StacksBlockId(as_hash(1)));
+        let mut marf_store = marf.begin(&StacksBlockId(as_hash(60)), &StacksBlockId(as_hash(61)));
 
         let clarity_db = marf_store.as_clarity_db(&headers_db, &NULL_BURN_STATE_DB);
 
@@ -2596,6 +2596,16 @@ fn bench_poison_microblock(c: &mut Criterion) {
     );
 }
 
+fn bench_contract_call(c: &mut Criterion) {
+    bench_with_input_sizes(
+        c,
+        ClarityCostFunction::ContractCall,
+        SCALE.into(),
+        vec![1],
+        true
+    )
+}
+
 criterion_group!(
     benches,
     // bench_add,
@@ -2708,12 +2718,13 @@ criterion_group!(
     // bench_contract_storage,
     // bench_principal_of,
     // bench_stx_transfer,
-    bench_stx_get_balance,
-    bench_analysis_pass_read_only, // g
-    bench_analysis_pass_arithmetic_only_checker, // g
-    bench_analysis_pass_trait_checker, // g
-    bench_analysis_pass_type_checker, // g
-    bench_poison_microblock,
+    // bench_stx_get_balance,
+    // bench_analysis_pass_read_only, // g
+    // bench_analysis_pass_arithmetic_only_checker, // g
+    // bench_analysis_pass_trait_checker, // g
+    // bench_analysis_pass_type_checker, // g
+    // bench_poison_microblock,
+    bench_contract_call,
 );
 
 criterion_main!(benches);

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1913,6 +1913,28 @@ pub fn gen_analysis_pass_type_checker(input_size: u16) -> (Option<String>, Strin
 }
 
 /// Returns tuple of optional setup clarity code, and "main" clarity code
+pub fn gen_analysis_pass(function: AnalysisCostFunction, _scale: u16, input_size: u16) -> (Option<String>, String) {
+    match function {
+        AnalysisCostFunction::ReadOnly => gen_analysis_pass_read_only(input_size),
+        AnalysisCostFunction::TypeChecker => gen_analysis_pass_type_checker(input_size),
+        AnalysisCostFunction::TraitChecker => gen_analysis_pass_trait_checker(input_size),
+        AnalysisCostFunction::ArithmeticOnlyChecker => gen_analysis_pass_arithmetic_only(input_size),
+    }
+}
+
+// contract-call-bench? does everything contract-call? does, except load and execute the contract code
+pub fn gen_contract_call(scale: u16) -> (Option<String>, String) {
+    // let mut setup_body = String::new();
+    let mut body = String::new();
+
+    for _ in 0..scale {
+        body.push_str("(contract-call-bench? 'SP000000000000000000002Q6VF78.cost-voting get-counter) ");
+    }
+
+    (None, body)
+}
+
+/// Returns tuple of optional setup clarity code, and "main" clarity code
 pub fn gen(function: ClarityCostFunction, scale: u16, input_size: u16) -> (Option<String>, String) {
     match function {
         // arithmetic
@@ -2007,7 +2029,7 @@ pub fn gen(function: ClarityCostFunction, scale: u16, input_size: u16) -> (Optio
         ClarityCostFunction::NftOwner => gen_nft_owner("nft-get-owner?", scale),
         ClarityCostFunction::NftBurn => gen_nft_burn("nft-burn?", scale),
         // Stacks
-        ClarityCostFunction::PoisonMicroblock => unimplemented!(),
+        ClarityCostFunction::PoisonMicroblock => unimplemented!(), // don't need a gen for this
         ClarityCostFunction::BlockInfo => gen_get_block_info(scale),
         ClarityCostFunction::StxBalance => gen_stx_get_balance(scale),
         ClarityCostFunction::StxTransfer => gen_stx_transfer(scale),
@@ -2057,21 +2079,11 @@ pub fn gen(function: ClarityCostFunction, scale: u16, input_size: u16) -> (Optio
         ClarityCostFunction::TypeParseStep => gen_type_parse_step(scale), // called by `parse_type_repr` in `signatures.rs` (takes in symbolic expression)
         // Uncategorized
         ClarityCostFunction::UserFunctionApplication => gen_analysis_get_function_entry(input_size),
-        ClarityCostFunction::ContractCall => unimplemented!(),
+        ClarityCostFunction::ContractCall => gen_contract_call(scale),
+        // ClarityCostFunction::ContractCallBench => gen_contract_call(scale),
         ClarityCostFunction::ContractOf => unimplemented!(),
         ClarityCostFunction::PrincipalOf => gen_principal_of(scale),
         ClarityCostFunction::AtBlock => gen_at_block(scale),
         ClarityCostFunction::LoadContract => unimplemented!(), // called at start of execute_contract
-    }
-}
-
-
-/// Returns tuple of optional setup clarity code, and "main" clarity code
-pub fn gen_analysis_pass(function: AnalysisCostFunction, _scale: u16, input_size: u16) -> (Option<String>, String) {
-    match function {
-        AnalysisCostFunction::ReadOnly => gen_analysis_pass_read_only(input_size),
-        AnalysisCostFunction::TypeChecker => gen_analysis_pass_type_checker(input_size),
-        AnalysisCostFunction::TraitChecker => gen_analysis_pass_trait_checker(input_size),
-        AnalysisCostFunction::ArithmeticOnlyChecker => gen_analysis_pass_arithmetic_only(input_size),
     }
 }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1924,7 +1924,6 @@ pub fn gen_analysis_pass(function: AnalysisCostFunction, _scale: u16, input_size
 
 // contract-call-bench? does everything contract-call? does, except load and execute the contract code
 pub fn gen_contract_call(scale: u16) -> (Option<String>, String) {
-    // let mut setup_body = String::new();
     let mut body = String::new();
 
     for _ in 0..scale {
@@ -2080,7 +2079,6 @@ pub fn gen(function: ClarityCostFunction, scale: u16, input_size: u16) -> (Optio
         // Uncategorized
         ClarityCostFunction::UserFunctionApplication => gen_analysis_get_function_entry(input_size),
         ClarityCostFunction::ContractCall => gen_contract_call(scale),
-        // ClarityCostFunction::ContractCallBench => gen_contract_call(scale),
         ClarityCostFunction::ContractOf => unimplemented!(),
         ClarityCostFunction::PrincipalOf => gen_principal_of(scale),
         ClarityCostFunction::AtBlock => gen_at_block(scale),


### PR DESCRIPTION
This wound up being a lot simpler than I thought! pushed some changes to make this work to the `dev/clarity-benchmarking` branch of the blockchain repo, including a `contract-call-bench?` function which is just like `contract-call?` but omits loading and executing the specified clarity function.