### PR TITLE
Fix bind name benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 name = "blockstack-core"
 version = "0.0.1"
-source = "git+https://github.com/blockstack/stacks-blockchain?branch=dev/clarity-benchmarking#d219261ba07f5a96e91cae29a96aa0203279f283"
+source = "git+https://github.com/blockstack/stacks-blockchain?branch=dev/clarity-benchmarking#df58a3ff60d8b1086fb36edaf80106717cef0334"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1283,7 +1283,7 @@ fn bench_analysis_bind_name(c: &mut Criterion) {
     ) {
         type_checker.type_map.delete_all();
         for exp in &contract_ast.expressions {
-            type_checker.try_type_check_define(&exp, local_context);
+            type_checker.bench_try_type_check_define(&exp, local_context);
         }
     }
 
@@ -1291,7 +1291,7 @@ fn bench_analysis_bind_name(c: &mut Criterion) {
         c,
         ClarityCostFunction::AnalysisBindName,
         SCALE,
-        vec![1],
+        INPUT_SIZES.into(),
         dummy_setup_code,
         eval_type_check_define,
     )

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -147,6 +147,24 @@ pub fn make_sized_tuple_sigs_map(input_sizes: Vec<u16>) -> HashMap<u16, TupleTyp
     ret_map
 }
 
+fn helper_make_clarity_type_for_sized_type_sig(input_size: u16) -> String {
+    match input_size {
+        1 => "uint".to_string(),
+        2 => "(optional bool)".to_string(),
+        n => {
+            let mult = n / 8;
+            // (tuple (key-name-0 key-type-0) (key-name-1 key-type-1) ...)
+            let mut key_pairs = String::new();
+            for i in 0..mult {
+                let id_name = if i < 10 { "id--" } else { "id-" };
+                let name = format!("{}{}", id_name, i);
+                key_pairs.push_str(&*format!("({} uint) ", name));
+            }
+            format!("(tuple {})", key_pairs)
+        }
+    }
+}
+
 fn helper_make_clarity_value_for_sized_type_sig(input_size: u16) -> String {
     let mut rng = rand::thread_rng();
     match input_size {
@@ -1585,28 +1603,30 @@ fn gen_analysis_option_check(scale: u16) -> (Option<String>, String) {
     (None, body)
 }
 
-fn gen_analysis_bind_name(scale: u16) -> (Option<String>, String) {
+fn gen_analysis_bind_name(scale: u16, input_size: u16) -> (Option<String>, String) {
     let mut body = String::new();
     let mut rng = rand::thread_rng();
 
-    for i in 0..scale {
-        let mut args = match rng.gen_range(0..3) {
+    for _ in 0..scale {
+        let var_name = "dummy-name";
+        let clar_type = helper_make_clarity_type_for_sized_type_sig(input_size);
+        let clar_val = helper_make_clarity_value_for_sized_type_sig(input_size);
+
+         match rng.gen_range(0..3) {
             0 => {
-                let (statement, _) = helper_define_fungible_token_statement();
-                statement
+                let args = format!("{} {} {}", var_name, clar_type, clar_val);
+                body.push_str(&*format!("(define-data-var {}) ", args));
             }
             1 => {
-                let (statement, _, _, _, _, _, _, _) = helper_create_map();
-                statement
+                let args = format!("{} {}", var_name, clar_val);
+                body.push_str(&*format!("(define-constant {}) ", args));
             }
             2 => {
-                let (_, statement) = gen_create_var(1);
-                statement
+                let args = format!("{} {}", var_name, clar_type);
+                body.push_str(&*format!("(define-non-fungible-token {}) ", args));
             }
             _ => unreachable!("Numbers out of range should not be generated."),
         };
-
-        body.push_str(&*format!("{} ", args));
     }
     println!("{}", body);
     (None, body)
@@ -1968,7 +1988,7 @@ pub fn gen(function: ClarityCostFunction, scale: u16, input_size: u16) -> (Optio
         ClarityCostFunction::AnalysisIterableFunc => gen_analysis_iterable_func(scale, input_size),
         ClarityCostFunction::AnalysisOptionCons => gen_analysis_option_cons(scale),
         ClarityCostFunction::AnalysisOptionCheck => gen_analysis_option_check(scale),
-        ClarityCostFunction::AnalysisBindName => gen_analysis_bind_name(scale),
+        ClarityCostFunction::AnalysisBindName => gen_analysis_bind_name(scale, input_size),
         ClarityCostFunction::AnalysisListItemsCheck => {
             gen_analysis_list_items_check(scale, input_size)
         }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -156,7 +156,8 @@ fn helper_make_clarity_type_for_sized_type_sig(input_size: u16) -> String {
             // (tuple (key-name-0 key-type-0) (key-name-1 key-type-1) ...)
             let mut key_pairs = String::new();
             for i in 0..mult {
-                let id_name = if i < 10 { "id--" } else { "id-" };
+                // the id name is constructed like this to ensure key names all have equal length
+                let id_name = if i < 10 { "id--" } else if i < 100 { "id-" } else { "id" };
                 let name = format!("{}{}", id_name, i);
                 key_pairs.push_str(&*format!("({} uint) ", name));
             }
@@ -175,7 +176,8 @@ fn helper_make_clarity_value_for_sized_type_sig(input_size: u16) -> String {
             // assume n is a multiple of 8
             let tuple_vals = (0..mult)
                 .map(|i| {
-                    let id_name = if i < 10 { "id--" } else { "id-" };
+                    // the id name is constructed like this to ensure key names all have equal length
+                    let id_name = if i < 10 { "id--" } else if i < 100 { "id-" } else { "id" };
                     format!("({}{} {})", id_name, i, rng.gen::<u32>())
                 })
                 .collect::<Vec<String>>()
@@ -226,7 +228,8 @@ fn make_sized_type_sig(input_size: u16) -> TypeSignature {
             let mut type_map = Vec::new();
             let mult = n / 8;
             for i in 0..mult {
-                let id_name = if i < 10 { "id--" } else { "id-" };
+                // the id name is constructed like this to ensure key names all have equal length
+                let id_name = if i < 10 { "id--" } else if i < 100 { "id-" } else {"id"};
                 let name = ClarityName::try_from(format!("{}{}", id_name, i)).unwrap();
                 let type_sig = type_list.choose(&mut rng).unwrap().clone();
                 type_map.push((name, type_sig));


### PR DESCRIPTION
We were getting a "NameAlreadyUsed" error when benchmarking this cost function. This PR fixes that error by calling a modified function in the blockchain repo. 

This PR also updates this bench function so that different input sizes are tested. 

The corresponding change in the stacks-blockchain repo has been pushed to `dev/clarity-benchmarking`. 